### PR TITLE
User search: Search also for full name

### DIFF
--- a/models/user.go
+++ b/models/user.go
@@ -443,7 +443,7 @@ func (i *UserQuery) PermittedUserFilter(token *AccessToken) bson.D {
 	filter.ElemMatchList("system_roles", "name", i.SystemRoles)
 	filter.EqualStringList("active.status", i.ActiveState)
 	filter.EqualStringList("nvm.status", i.NVMState)
-	filter.SearchString([]string{"_id", "first_name", "last_name", "email"}, i.Search)
+	filter.SearchString([]string{"_id", "first_name", "last_name", "full_name", "email"}, i.Search)
 	return filter.Bson()
 }
 


### PR DESCRIPTION
Currently, the users endpoint only searches for first or last name. So if you copy a full name, e.g. from the participants list, you won't find this person as the full string "Max Muster" does not match (first=Max, last=Muster).