### PR TITLE
Add a route to get artists with api token

### DIFF
--- a/handlers/token/artist.go
+++ b/handlers/token/artist.go
@@ -18,6 +18,7 @@ func (i *ArtistHandler) Routes(group *echo.Group) {
 	group.Use(i.Context)
 	group.POST("", i.Create, accessCookie)
 	group.GET("", i.Get, accessCookie)
+	group.GET("/api_token", i.Get, vcago.KeyAuthMiddleware())
 	group.GET("/:id", i.GetByID, accessCookie)
 	group.PUT("", i.Update, accessCookie)
 	group.DELETE("/:id", i.Delete, accessCookie)


### PR DESCRIPTION
For the tour tool, it would be helpful to be able to query the artists using a token (as for the user info, see #231).

As here's no user-specific filtering, my hope would be that this is enough. As I don't know how to setup the token locally, I just compared and pushed. Would be great, if you could check, @deinelieblings !