### PR TITLE
Add a route to get takings by event_id with token

### DIFF
--- a/dao/taking.go
+++ b/dao/taking.go
@@ -169,6 +169,18 @@ func TakingGetByIDSystem(ctx context.Context, id string) (result *models.Taking,
 	return
 }
 
+func TakingGetByEventIDSystem(ctx context.Context, eventId string) (result *models.Taking, err error) {
+	filter := bson.D{{Key: "event._id", Value: eventId}}
+	if err = TakingCollection.AggregateOne(
+		ctx,
+		models.TakingPipeline().Match(filter).Pipe,
+		&result,
+	); err != nil {
+		return
+	}
+	return
+}
+
 func TakingDeletetByIDSystem(ctx context.Context, id string) (err error) {
 	filter := bson.D{{Key: "_id", Value: id}}
 	err = TakingCollection.DeleteOne(ctx, filter)

--- a/handlers/token/taking.go
+++ b/handlers/token/taking.go
@@ -21,6 +21,7 @@ func (i *TakingHandler) Routes(group *echo.Group) {
 	group.PUT("", i.Update, accessCookie)
 	group.GET("", i.Get, accessCookie)
 	group.GET("/:id", i.GetByID, accessCookie)
+	group.GET("/by_event/:id", i.GetByEventIDKey, vcago.KeyAuthMiddleware())
 	group.DELETE("/:id", i.DeleteByID, accessCookie)
 
 }
@@ -89,6 +90,19 @@ func (i TakingHandler) GetByID(cc echo.Context) (err error) {
 	}
 	result := new(models.Taking)
 	if result, err = dao.TakingGetByID(c.Ctx(), body, token); err != nil {
+		return
+	}
+	return c.Selected(result)
+}
+
+func (i TakingHandler) GetByEventIDKey(cc echo.Context) (err error) {
+	c := cc.(vcago.Context)
+	body := new(vmod.IDParam)
+	if err = c.BindAndValidate(body); err != nil {
+		return
+	}
+	result := new(models.Taking)
+	if result, err = dao.TakingGetByEventIDSystem(c.Ctx(), body.ID); err != nil {
 		return
 	}
 	return c.Selected(result)


### PR DESCRIPTION
from Viva-con-Agua/tour#41

adds a route like http://pool-api.localhost/v1/finances/taking/by_event/055eb2df-a1d6-431a-a6ac-95fead397edc to get the taking which is assigned to the event or returns a not found, which is than in the responsibility of the user.
```
{
  "type": "error",
  "message": "document not found",
  "model": "takings"
}
```