### PR TITLE
Include organisation_id in EventDatabase

### DIFF
--- a/models/event.go
+++ b/models/event.go
@@ -370,6 +370,7 @@ func (i *EventCreate) EventDatabase(token *AccessToken) *EventDatabase {
 		Applications:          EventApplications{Confirmed: 0, Rejected: 0, Requested: 0, Withdrawn: 0, Total: 0},
 		EventTools:            i.EventTools,
 		EventState:            i.EventState,
+		OrganisationID: 	   i.OrganisationID,
 		CreatorID:             token.ID,
 		Modified:              vmod.NewModified(),
 	}

--- a/models/event.go
+++ b/models/event.go
@@ -370,7 +370,7 @@ func (i *EventCreate) EventDatabase(token *AccessToken) *EventDatabase {
 		Applications:          EventApplications{Confirmed: 0, Rejected: 0, Requested: 0, Withdrawn: 0, Total: 0},
 		EventTools:            i.EventTools,
 		EventState:            i.EventState,
-		OrganisationID: 	   i.OrganisationID,
+		OrganisationID:        i.OrganisationID,
 		CreatorID:             token.ID,
 		Modified:              vmod.NewModified(),
 	}


### PR DESCRIPTION
fixes Viva-con-Agua/pool-webapp#527: Keep organisation id as given by input event