### PR TITLE
Update role update to allow roles without nvm for non-german crews

### DIFF
--- a/models/role.go
+++ b/models/role.go
@@ -1,6 +1,7 @@
 package models
 
 import (
+	"os"
 	"time"
 
 	"github.com/Viva-con-Agua/vcago"
@@ -122,7 +123,7 @@ var ASPRole = "other;asp;finance;operation;education;network;socialmedia;awarene
 var ASPEventRole = "network;operation;education"
 
 func RolesPermission(role string, user *User, token *AccessToken) (err error) {
-	if user.NVM.Status != "confirmed" {
+	if os.Getenv("VCA_ORG_DE") == user.Crew.OrganisationID && user.NVM.Status != "confirmed" {
 		return vcago.NewBadRequest(PoolRoleCollection, "nvm required", nil)
 	}
 	if !(token.Roles.Validate("admin;employee;pool_employee") || token.PoolRoles.Validate(role)) {

--- a/models/role_history.go
+++ b/models/role_history.go
@@ -1,6 +1,7 @@
 package models
 
 import (
+	"os"
 	"strconv"
 
 	"github.com/Viva-con-Agua/vcago"
@@ -80,7 +81,7 @@ func RolesHistoryPermittedPipeline() (pipe *vmdb.Pipeline) {
 }
 
 func RolesHistoryPermission(user *User, token *AccessToken) (err error) {
-	if user.NVM.Status != "confirmed" {
+	if os.Getenv("VCA_ORG_DE") == user.OrganisationID && user.NVM.Status != "confirmed" {
 		return vcago.NewBadRequest(PoolRoleHistoryCollection, "nvm required", nil)
 	}
 	if !(token.Roles.Validate("admin;employee;pool_employee") || token.PoolRoles.Validate(ASPRole)) {


### PR DESCRIPTION
see https://github.com/Viva-con-Agua/pool-webapp/issues/529

needs additionally, an .env-Variable VCA_ORG_DE which holds the ID of the german VcA organisation (see Viva-con-Agua/pool-api-deploy#4)