### PR TITLE
Remove the user limit on getting all users of a crew

### DIFF
--- a/dao/users.go
+++ b/dao/users.go
@@ -52,7 +52,7 @@ func UsersGet(i *models.UserQuery, token *models.AccessToken) (result *[]models.
 	var cErr error
 	ctxCount, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
-	if cErr = UserCollection.AggregateOne(ctxCount, models.SortedUserPermittedPipeline(token).Match(filter).Limit(500, 500).Count().Pipe, &count); cErr != nil {
+	if cErr = UserCollection.AggregateOne(ctxCount, models.SortedUserPermittedPipeline(token).Match(filter).Count().Pipe, &count); cErr != nil {
 		log.Print(cErr)
 		listSize = 0
 	} else {


### PR DESCRIPTION
As discussed today with @Gero-VcA 

The users endpoint only returns a maximum of 500 users on the following endpoint:
https://pool-api.dev.vivaconagua.org/v1/users

This is a problem on big crews, like e.g. Hamburg or Berlin, and leading to missing users in the list of users and the crew selection of ASPs (on the crew page)

